### PR TITLE
log stderr messages from update script

### DIFF
--- a/pistar-update
+++ b/pistar-update
@@ -134,7 +134,7 @@ if [ -t 1 ]; then
   main_function
 else
   # if not run via terminal, log everything into a log file
-  main_function 2>&1 >> /var/log/pi-star/pi-star_update.log
+  main_function >> /var/log/pi-star/pi-star_update.log 2>&1
 fi
 
 exit 0

--- a/pistar-upgrade
+++ b/pistar-upgrade
@@ -275,7 +275,7 @@ if [ -t 1 ]; then
   main_function
 else
   # if not run via terminal, log everything into a log file
-  main_function 2>&1 >> /var/log/pi-star/pi-star_upgrade.log
+  main_function >> /var/log/pi-star/pi-star_upgrade.log 2>&1
 fi
 
 exit 0


### PR DESCRIPTION
I'm not sure if this is a mistake or intentional but IMO it's useful to log stderr messages... for eg. when git commands fail for some reason, currently it's impossible to determine that while doing update on the web interface...