### PR TITLE
prevent running multiple instances of update script simultaneously

### DIFF
--- a/pistar-update
+++ b/pistar-update
@@ -15,6 +15,12 @@ if [ "$(id -u)" != "0" ]; then
   exit 1
 fi
 
+exec 200>/var/lock/pistar-update.lock || exit 1
+if ! flock -n 200 ; then
+  echo -e "Another instance is already running...\n"
+  exit 1
+fi
+
 main_function() {
 	# Make the disk writable
 	mount -o remount,rw /


### PR DESCRIPTION
think it may be important to prevent running multiple instances of update script simultaneously because this script is called from the web interface and user may refresh page, etc... causing it to run multiple times...