### PR TITLE
Matching the XLX ID instead of IP address while overridden XLXHosts.txt

### DIFF
--- a/HostFilesUpdate.sh
+++ b/HostFilesUpdate.sh
@@ -110,8 +110,8 @@ if [ -f "/root/XLXHosts.txt" ]; then
 	while IFS= read -r line; do
 		if [[ $line != \#* ]]
 		then
-			ip=`echo $line | awk -F  ";" '{print $2}'`
-			/bin/sed -i "/$ip/c\\$line" /usr/local/etc/XLXHosts.txt
+			xlxid=`echo $line | awk -F  ";" '{print $1}'`
+			/bin/sed -i "/$xlxid\;/c\\$line" /usr/local/etc/XLXHosts.txt
 		fi
 	done < /root/XLXHosts.txt
 fi

--- a/HostFilesUpdate.sh
+++ b/HostFilesUpdate.sh
@@ -111,7 +111,7 @@ if [ -f "/root/XLXHosts.txt" ]; then
 		if [[ $line != \#* ]]
 		then
 			xlxid=`echo $line | awk -F  ";" '{print $1}'`
-			/bin/sed -i "/$xlxid\;/c\\$line" /usr/local/etc/XLXHosts.txt
+			/bin/sed -i "/^$xlxid\;/c\\$line" /usr/local/etc/XLXHosts.txt
 		fi
 	done < /root/XLXHosts.txt
 fi


### PR DESCRIPTION
Hello Andy,

Not sure if this is your original intention, but IP address will not be overridden by matching the IP address.

The missing leading '^' in the REGEXP issue has been resolved.

Regards,
Yngwie Chou

