### PR TITLE
Leave P25HostsLocal alone on update

### DIFF
--- a/HostFilesUpdate.sh
+++ b/HostFilesUpdate.sh
@@ -113,9 +113,6 @@ if [[ $(/usr/local/bin/P25Gateway --version | awk '{print $3}' | cut -c -8) -gt 
 	sed -i 's/Hosts=\/usr\/local\/etc\/P25Hosts.txt/HostsFile1=\/usr\/local\/etc\/P25Hosts.txt\nHostsFile2=\/usr\/local\/etc\/P25HostsLocal.txt/g' /etc/p25gateway
 	sed -i 's/HostsFile2=\/root\/P25Hosts.txt/HostsFile2=\/usr\/local\/etc\/P25HostsLocal.txt/g' /etc/p25gateway
 fi
-if [ -f "/root/P25Hosts.txt" ]; then
-	cat /root/P25Hosts.txt > /usr/local/etc/P25HostsLocal.txt
-fi
 
 # If there is an XLX over-ride
 if [ -f "/root/XLXHosts.txt" ]; then


### PR DESCRIPTION
P25HostsLocal is a great way for users to easily add talk groups to their own reflectors either for linking local ham repeaters or simply adding 3rd party reflectors to their hotspot or repeater. Previously the update would overwrite these changes and wipe out the local hosts file.