### PR TITLE
fix nxdnparrot not starting with just dmr2nxdn enabled

### DIFF
--- a/nxdnparrot.service
+++ b/nxdnparrot.service
@@ -31,12 +31,12 @@ test -r $CONFIG || exit 1
 
 if [ `sed -n '/\[NXDN Network\]/{n;p;}' /etc/mmdvmhost | cut -c 8` == 0 ]; then
 	if [ -f '/etc/ysf2nxdn' ] && [ `sed -n '/\[Enabled\]/{n;p;}' /etc/ysf2nxdn | cut -c 9` == 0 ]; then
-		exit 1;
+		if [ -f '/etc/dmr2nxdn' ] && [ `sed -n '/\[Enabled\]/{n;p;}' /etc/dmr2nxdn | cut -c 9` == 0 ]; then
+			exit 1;
+		elif [ -f '/etc/dmr2nxdn' ] && [ `sed -n '/\[Enabled\]/{n;p;}' /etc/dmr2nxdn | cut -c 9` == 1 ]; then
+			test=pass
+		fi
 	elif [ -f '/etc/ysf2nxdn' ] && [ `sed -n '/\[Enabled\]/{n;p;}' /etc/ysf2nxdn | cut -c 9` == 1 ]; then
-		test=pass
-	elif [ -f '/etc/dmr2nxdn' ] && [ `sed -n '/\[Enabled\]/{n;p;}' /etc/dmr2nxdn | cut -c 9` == 0 ]; then
-		exit 1;
-	elif [ -f '/etc/dmr2nxdn' ] && [ `sed -n '/\[Enabled\]/{n;p;}' /etc/dmr2nxdn | cut -c 9` == 1 ]; then
 		test=pass
 	else
 		exit 1;


### PR DESCRIPTION
For this commit I did just copy exactly what you have on nxdngateway.service ... but tbh I really don't like it :)  Why don't you do something more simple and clear like:

```
if [ `sed -n '/\[NXDN Network\]/{n;p;}' /etc/mmdvmhost | cut -c 8` == 0 ]; then
	if [ -f '/etc/ysf2nxdn' ] && [ `sed -n '/\[Enabled\]/{n;p;}' /etc/ysf2nxdn | cut -c 9` != 1 ]; then
		if [ -f '/etc/dmr2nxdn' ] && [ `sed -n '/\[Enabled\]/{n;p;}' /etc/dmr2nxdn | cut -c 9` != 1 ]; then
			exit 1;
		fi
	fi
fi
```

I don't see the need for the test=pass and redundant if's that make it more complex... and when you add a 3rd converter app there it will get much worst... :)