### PR TITLE
pistar-mmdvmcal: fix typo remounting fs ro

### DIFF
--- a/pistar-mmdvmcal
+++ b/pistar-mmdvmcal
@@ -51,7 +51,7 @@ killall MMDVMCal >/dev/null 2>&1
 echo "Starting Pi-Star Services..."
 
 # Set the disk back to RO on MMDVMCal exit
-mount -o remount,rw /
+mount -o remount,ro /
 
 # Start the services
 systemctl start pistar-watchdog.timer


### PR DESCRIPTION
actually maybe there is no need to even remount it rw... afaik mmdvmcal doesn't write any settings?