### PR TITLE
pistar-update: restrict hash checking to master branch + typos.

### DIFF
--- a/pistar-update
+++ b/pistar-update
@@ -27,7 +27,7 @@ git_checkUpdateRequired() {
 	gitRemoteURL=$(git --work-tree=${gitFolder} --git-dir=${gitFolder}/.git config --get remote.origin.url)
 
 	# Git check / update function
-	gitStatusRemote=$(git ls-remote --heads ${gitRemoteURL} | cut -c 1-7)
+	gitStatusRemote=$(git ls-remote --heads ${gitRemoteURL} | grep master | cut -c 1-7)
 	gitStatusLocal=$(git --work-tree=${gitFolder} --git-dir=${gitFolder}/.git log --pretty=format:"%h" -1)
 
 	# Return the output
@@ -58,7 +58,7 @@ git_update() {
 		
 		# Re-check that the updates are now good
 		if [[ $(git_checkUpdateRequired ${gitFolder}) -gt 0 ]]; then
-			echo "Updates were not sucsessfull, reverting to Pi-Star origional files..."
+			echo "Updates were not successfull, reverting to Pi-Star original files..."
 			git --work-tree=${gitFolder} --git-dir=${gitFolder}/.git reset --hard origin/master
 		fi
 	else


### PR DESCRIPTION
Restrict ls-remote to master branch only.
Typos.
