### PR TITLE
minor fix on pistar-update

### DIFF
--- a/pistar-update
+++ b/pistar-update
@@ -53,7 +53,7 @@ git_update() {
 		# If this script is updated, re-run the update with the new version.
 		if [[ ${gitFolder} == "/usr/local/sbin" ]]; then
                         git fetch
-                        [ -n $(git diff --name-only origin/master | grep pistar-update) ] && {
+                        [ -n $(git --work-tree=${gitFolder} --git-dir=${gitFolder}/.git diff --name-only origin/master | grep pistar-update) ] && {
                                 echo "Found a new version of pistar-update..."
                                 git --work-tree=${gitFolder} --git-dir=${gitFolder}/.git pull origin master
                                 if [[ $(git_checkUpdateRequired ${gitFolder}) -gt 0 ]]; then
@@ -64,10 +64,8 @@ git_update() {
                                 exec "$0" "$@"
                                 exit 1
                         }
-                        git --work-tree=${gitFolder} --git-dir=${gitFolder}/.git pull origin master
-                else
-                        git --work-tree=${gitFolder} --git-dir=${gitFolder}/.git pull origin master
                 fi
+                git --work-tree=${gitFolder} --git-dir=${gitFolder}/.git pull origin master
 
 		# Re-check that the updates are now good
 		if [[ $(git_checkUpdateRequired ${gitFolder}) -gt 0 ]]; then


### PR DESCRIPTION
the git diff line wasn't actually doing anything and script was wrongly re-running itself every time there is any change on sbin dir, even if not on update script (noticed it today while it updating just pistar-hourly.cron), also removed redundant line...