### PR TITLE
fix upnp timeout issue (with at least some routers)

### DIFF
--- a/pistar-upnp.service
+++ b/pistar-upnp.service
@@ -18,7 +18,7 @@ KILL=/bin/kill
 SLEEP=/bin/sleep
 ipVar=$(hostname -I | cut -d' ' -f1)
 hostVar=$(hostname | cut -d'.' -f1)
-timeOut=600
+timeOut=$(( ($(date +%s -d "tomorrow 3:59") - $(date +%s)) % 86400 ))
 
 # Pre-flight checks...
 test -x ${DAEMON_PATH}${DAEMON} || exit 1


### PR DESCRIPTION
This is a purpose to fix the upnp timeout issue that we discussed some days ago (with at least some routers, that don't refresh/reset timeout on repeated upnp requests to add port mappings).

This patch ensures that all upnp port mappings timeout will expire every day at 3:59, this will cause a minor blackout at that time (that is unlikely there are users using the hotspot), ports will then re-open at 4:00 when the script runs again (every 5 min). I think this is the best solution to continue using timeout in a reliable way.

(note: the modulus calc will handle the fact that after midnight and before the hit time we don't want it to expire on next day)