### PR TITLE
correct integer compare stmt

### DIFF
--- a/pistar-bmapi
+++ b/pistar-bmapi
@@ -61,7 +61,7 @@ fi
 
 # Get the stored BM API Key
 if [ -f ${APIKeyFile} ]; then
-	if [[ $(wc -c ${APIKeyFile} | awk '{print $1}') > 200 ]]; then
+	if [[ $(wc -c ${APIKeyFile} | awk '{print $1}') -gt 200 ]]; then
 		echo -e "Using BM API v2"
 		APIURL="https://api.brandmeister.network/v2/device/"
 		APIKey=$(grep -m 1 'apikey=' ${APIKeyFile} | awk -F "=" '/apikey/ {print $2}')


### PR DESCRIPTION
Some of my systems are reporting V1 BM API keys instead of V2 even though they all had been updated to V2. Investigation showed systems with keys 1000 chars long were being reported as V1 (via pistar-bmapi apikey cmd) while keys 999 chars long were displaying as V2. Problem traced to the use of ">" instead of "-gt" for an integer compare. 