### PR TITLE
Fix broken pistar-mmdvmhshatflash and pistar-mmdvmhshatdowngrade due to GH URI changes

### DIFF
--- a/pistar-mmdvmhshatdowngrade
+++ b/pistar-mmdvmhshatdowngrade
@@ -117,7 +117,8 @@ then
             rm -rf /tmp/mmdvmhshatfirmware 2> /dev/null
             mkdir /tmp/mmdvmhshatfirmware 2> /dev/null
             echo "Flashing your ${1} modem to version ${VERSION}"
-            curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/${VERSION} | egrep -o '/juribeparada/MMDVM_HS/releases/download/v[0-9.]*/install_fw_hshat.sh' | wget --base=http://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
+    	    GHbase=$(curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/${VERSION} | egrep -o '/juribeparada/MMDVM_HS/releases/expanded_assets/'${VERSION} | sed 's/expanded_assets/download/')        
+	    echo $GHbase/install_fw_hshat.sh | wget --base=https://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
             chmod +x /tmp/mmdvmhshatfirmware/flash.sh
             cd  /tmp/mmdvmhshatfirmware
             ./flash.sh
@@ -132,7 +133,8 @@ then
             rm -rf /tmp/mmdvmhshatfirmware 2> /dev/null
             mkdir /tmp/mmdvmhshatfirmware 2> /dev/null
             echo "Flashing your ${1} modem to the ${VERSION} version"
-            curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/${VERSION} | egrep -o '/juribeparada/MMDVM_HS/releases/download/v[0-9.]*/install_fw_hshat-12mhz.sh' | wget --base=http://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
+            GHbase=$(curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/${VERSION} | egrep -o '/juribeparada/MMDVM_HS/releases/expanded_assets/'${VERSION} | sed 's/expanded_assets/download/')        
+            echo $GHbase/install_fw_hshat-12mhz.sh | wget --base=https://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
             chmod +x /tmp/mmdvmhshatfirmware/flash.sh
             cd  /tmp/mmdvmhshatfirmware
             ./flash.sh
@@ -147,7 +149,8 @@ then
             rm -rf /tmp/mmdvmhshatfirmware 2> /dev/null
             mkdir /tmp/mmdvmhshatfirmware 2> /dev/null
             echo "Flashing your ${1} modem to the ${VERSION} version"
-            curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/${VERSION} | egrep -o '/juribeparada/MMDVM_HS/releases/download/v[0-9.]*/install_fw_hsdualhat.sh' | wget --base=http://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
+            GHbase=$(curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/${VERSION} | egrep -o '/juribeparada/MMDVM_HS/releases/expanded_assets/'${VERSION} | sed 's/expanded_assets/download/')        
+            echo $GHbase/install_fw_hsdualhat.sh | wget --base=https://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
             chmod +x /tmp/mmdvmhshatfirmware/flash.sh
             cd  /tmp/mmdvmhshatfirmware
             ./flash.sh
@@ -162,7 +165,8 @@ then
             rm -rf /tmp/mmdvmhshatfirmware 2> /dev/null
             mkdir /tmp/mmdvmhshatfirmware 2> /dev/null
             echo "Flashing your ${1} modem to the ${VERSION} version"
-            curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/${VERSION} | egrep -o '/juribeparada/MMDVM_HS/releases/download/v[0-9.]*/install_fw_hsdualhat-12mhz.sh' | wget --base=http://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
+            GHbase=$(curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/${VERSION} | egrep -o '/juribeparada/MMDVM_HS/releases/expanded_assets/'${VERSION} | sed 's/expanded_assets/download/')        
+            echo $GHbase/install_fw_hsdualhat-12mhz.sh | wget --base=https://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
             chmod +x /tmp/mmdvmhshatfirmware/flash.sh
             cd  /tmp/mmdvmhshatfirmware
             ./flash.sh

--- a/pistar-mmdvmhshatflash
+++ b/pistar-mmdvmhshatflash
@@ -78,7 +78,8 @@ then
     rm -rf /tmp/mmdvmhshatfirmware 2> /dev/null
     mkdir /tmp/mmdvmhshatfirmware 2> /dev/null
     echo "Flashing your ${1} modem to the latest version"
-    curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/latest | egrep -o '/juribeparada/MMDVM_HS/releases/download/v[0-9.]*/install_fw_hshat.sh' | wget --base=http://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
+    GHbase=$(curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/latest | egrep -o '/juribeparada/MMDVM_HS/releases/expanded_assets/v[0-9.]*' | sed 's/expanded_assets/download/')
+    echo $GHbase/install_fw_hshat.sh | wget --base=https://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
     chmod +x /tmp/mmdvmhshatfirmware/flash.sh
     cd  /tmp/mmdvmhshatfirmware
     ./flash.sh
@@ -93,7 +94,8 @@ then
     rm -rf /tmp/mmdvmhshatfirmware 2> /dev/null
     mkdir /tmp/mmdvmhshatfirmware 2> /dev/null
     echo "Flashing your ${1} modem to the latest version"
-    curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/latest | egrep -o '/juribeparada/MMDVM_HS/releases/download/v[0-9.]*/install_fw_hshat-12mhz.sh' | wget --base=http://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
+    GHbase=$(curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/latest | egrep -o '/juribeparada/MMDVM_HS/releases/expanded_assets/v[0-9.]*' | sed 's/expanded_assets/download/')
+    echo $GHbase/install_fw_hshat-12mhz.sh | wget --base=https://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
     chmod +x /tmp/mmdvmhshatfirmware/flash.sh
     cd  /tmp/mmdvmhshatfirmware
     ./flash.sh
@@ -108,7 +110,8 @@ then
     rm -rf /tmp/mmdvmhshatfirmware 2> /dev/null
     mkdir /tmp/mmdvmhshatfirmware 2> /dev/null
     echo "Flashing your ${1} modem to the latest version"
-    curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/latest | egrep -o '/juribeparada/MMDVM_HS/releases/download/v[0-9.]*/install_fw_hsdualhat.sh' | wget --base=http://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
+    GHbase=$(curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/latest | egrep -o '/juribeparada/MMDVM_HS/releases/expanded_assets/v[0-9.]*' | sed 's/expanded_assets/download/')
+    echo $GHbase/install_fw_hsdualhat.sh | wget --base=https://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
     chmod +x /tmp/mmdvmhshatfirmware/flash.sh
     cd  /tmp/mmdvmhshatfirmware
     ./flash.sh
@@ -123,7 +126,8 @@ then
     rm -rf /tmp/mmdvmhshatfirmware 2> /dev/null
     mkdir /tmp/mmdvmhshatfirmware 2> /dev/null
     echo "Flashing your ${1} modem to the latest version"
-    curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/latest | egrep -o '/juribeparada/MMDVM_HS/releases/download/v[0-9.]*/install_fw_hsdualhat-12mhz.sh' | wget --base=http://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
+    GHbase=$(curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/latest | egrep -o '/juribeparada/MMDVM_HS/releases/expanded_assets/v[0-9.]*' | sed 's/expanded_assets/download/')
+    echo $GHbase/install_fw_hsdualhat-12mhz.sh | wget --base=https://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
     chmod +x /tmp/mmdvmhshatfirmware/flash.sh
     cd  /tmp/mmdvmhshatfirmware
     ./flash.sh
@@ -138,7 +142,8 @@ then
     rm -rf /tmp/mmdvmhshatfirmware 2> /dev/null
     mkdir /tmp/mmdvmhshatfirmware 2> /dev/null
     echo "Flashing your ${1} modem to the latest version"
-    curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/latest | egrep -o '/juribeparada/MMDVM_HS/releases/download/v[0-9.]*/install_fw_d2rg_mmdvmhs.sh' | wget --base=http://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
+    GHbase=$(curl -s -L https://github.com/juribeparada/MMDVM_HS/releases/latest | egrep -o '/juribeparada/MMDVM_HS/releases/expanded_assets/v[0-9.]*' | sed 's/expanded_assets/download/')
+    echo $GHbase/install_fw_d2rg_mmdvmhs.sh | wget --base=https://github.com/ -i - -O /tmp/mmdvmhshatfirmware/flash.sh
     chmod +x /tmp/mmdvmhshatfirmware/flash.sh
     cd  /tmp/mmdvmhshatfirmware
     ./flash.sh


### PR DESCRIPTION
ShitHub changed their URI schemas, as a result, broke `pistar-mmdvmhshatflash` and `pistar-mmdvmhshatdowngrade`. This code change/commit fixes ShitHub's terrible URI management blunders.