### PR TITLE
add an extra 0 before sending the request to RemoteCommand.

### DIFF
--- a/pistar-ysflink
+++ b/pistar-ysflink
@@ -52,7 +52,11 @@ unlink)
     echo -e "Invalid target ${1}"
     exit 1
   fi
-  (cd /var/log/pi-star/; ${cmd} ${port} Link${1^^})
+  REF=${1^^}
+  PREFIX=${REF: 0:3}
+  SUFFIX=${REF: 3}
+  NEWREF=${PREFIX}0${SUFFIX}
+  (cd /var/log/pi-star/; ${cmd} ${port} Link${NEWREF})
   exit 0
 ;;
 esac


### PR DESCRIPTION
Not sure if this is the right approach, but so far it is the only solution I came up with to allow linking using the pistar-ysflink.

For more info check the post I did in the facebook group page.
https://www.facebook.com/share/p/1EfyokpTGW/